### PR TITLE
Make function private so that swagger doesn't complain

### DIFF
--- a/Gcpe.Hub.API/Controllers/MessagesController.cs
+++ b/Gcpe.Hub.API/Controllers/MessagesController.cs
@@ -26,7 +26,7 @@ namespace Gcpe.Hub.API.Controllers
         }
 
         // Bumps the sort order of all published messages from firstSortOrder to lastSortOrder
-        public int BumpSortOrders(int direction, int firstSortOrder, int? lastSortOrder)
+        private int BumpSortOrders(int direction, int firstSortOrder, int? lastSortOrder)
         {
             IQueryable<Message> messages = dbContext.Message.Where(m => m.IsPublished && m.IsActive && m.SortOrder >= firstSortOrder);
             if (lastSortOrder != null)


### PR DESCRIPTION
This needs to be static so that swagger doesn't try to parse the method as an http end point