### PR TITLE
Remove the LastUpdateTimeStamp check

### DIFF
--- a/Gcpe.Hub.API/Controllers/ActivitiesController.cs
+++ b/Gcpe.Hub.API/Controllers/ActivitiesController.cs
@@ -61,8 +61,7 @@ namespace Gcpe.Hub.API.Controllers
             try
             {
                 IQueryable<Activity> forecast = Forecast(dbContext);
-                //var today = DateTime.Today;
-                var today = new DateTime(2019, 4, 12);
+                var today = DateTime.Today;
                 if (lastModifiedNextCheck.Date != today)
                 {
                     Request.GetTypedHeaders().IfModifiedSince = null; // force refresh after midnight

--- a/Gcpe.Hub.API/Controllers/ActivitiesController.cs
+++ b/Gcpe.Hub.API/Controllers/ActivitiesController.cs
@@ -68,8 +68,9 @@ namespace Gcpe.Hub.API.Controllers
                 }
                 forecast = forecast.Where(a => a.StartDateTime >= today && a.StartDateTime < today.AddDays(numDays));
 
-                IActionResult res = HandleModifiedSince(ref lastModified, ref lastModifiedNextCheck, () => forecast.OrderByDescending(a => a.LastUpdatedDateTime).FirstOrDefault()?.LastUpdatedDateTime);
-                return res ?? Ok(forecast.Where(a => a.IsActive).OrderBy(a => a.StartDateTime).Select(a => mapper.Map<Models.Activity>(a)).ToList());
+                // remove the check for modification only for 7 days forecast
+                // reason: hq amdin does not want to update the LastUpdateTimeStamp in corp calendar for activities with hq-1 tag
+                return Ok(forecast.Where(a => a.IsActive).OrderBy(a => a.StartDateTime).Select(a => mapper.Map<Models.Activity>(a)).ToList());
             }
             catch (Exception ex)
             {

--- a/Gcpe.Hub.API/Controllers/ActivitiesController.cs
+++ b/Gcpe.Hub.API/Controllers/ActivitiesController.cs
@@ -55,13 +55,14 @@ namespace Gcpe.Hub.API.Controllers
         [Produces(typeof(IEnumerable<Models.Activity>))]
         [ProducesResponseType(304)]
         [ProducesResponseType(400)]
-        [ResponseCache(Duration = 60)]
+        [ResponseCache(Duration = 5)]
         public IActionResult GetActivityForecast(int numDays)
         {
             try
             {
                 IQueryable<Activity> forecast = Forecast(dbContext);
-                var today = DateTime.Today;
+                //var today = DateTime.Today;
+                var today = new DateTime(2019, 4, 12);
                 if (lastModifiedNextCheck.Date != today)
                 {
                     Request.GetTypedHeaders().IfModifiedSince = null; // force refresh after midnight


### PR DESCRIPTION
-- removed the lastUpdateTimeStamp check due to the corp cal logic (hq admins do not want to update the LastUpdateTimeStamp for activities tagged as hq-1)